### PR TITLE
Fix/bad substitution

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -13,10 +13,39 @@ uuid = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
 uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 
 [[deps.Comonicon]]
-deps = ["Configurations", "ExproniconLite", "Libdl", "Logging", "Markdown", "PackageCompiler", "Pkg", "Scratch", "TOML", "UUIDs"]
-git-tree-sha1 = "c0a8d2369e6f1591d73aa418d6d58319913214ea"
+deps = ["ComoniconBuilder", "ComoniconOptions", "ComoniconTargetExpr", "ComoniconTypes", "ComoniconZSHCompletion", "Configurations", "ExproniconLite", "Markdown", "Pkg"]
+git-tree-sha1 = "3ad48ea7ea9ec4659514c95c26f81bdd89894d12"
 uuid = "863f3e99-da2a-4334-8734-de3dacbe5542"
-version = "0.12.2"
+version = "0.11.7"
+
+[[deps.ComoniconBuilder]]
+deps = ["ComoniconOptions", "ComoniconTypes", "ComoniconZSHCompletion", "Libdl", "Logging", "PackageCompiler"]
+git-tree-sha1 = "9a718f5b8a2121b572eb3c53f9319c169341e154"
+uuid = "0acea522-3a8c-4b93-9211-1fc67cbf95d9"
+version = "0.1.4"
+
+[[deps.ComoniconOptions]]
+deps = ["Configurations", "TOML"]
+git-tree-sha1 = "30408d3b8e4eefbfefa60447c6eaa46e820eb808"
+uuid = "a25bc8ac-9d24-42b2-8edd-3d267ec19fc5"
+version = "0.1.2"
+
+[[deps.ComoniconTargetExpr]]
+deps = ["ComoniconOptions", "ComoniconTypes", "ExproniconLite"]
+git-tree-sha1 = "7bd6c2a515cf2fc007ffe61b5de21a12ad120baa"
+uuid = "d6dfd36b-42f3-4a9f-a1cb-6f1a052fed42"
+version = "0.2.4"
+
+[[deps.ComoniconTypes]]
+git-tree-sha1 = "3ed67384a353e88a9140db8bf274aee75af9d36a"
+uuid = "d0eb39ce-029e-40d1-add6-e32b3165f6a3"
+version = "0.2.0"
+
+[[deps.ComoniconZSHCompletion]]
+deps = ["ComoniconTypes"]
+git-tree-sha1 = "225ff13b22f4c88aeb70ce20e89b016c1897790b"
+uuid = "dcf03e4a-d036-4ede-96c9-024e9e9eed12"
+version = "0.2.0"
 
 [[deps.CompilerSupportLibraries_jll]]
 deps = ["Artifacts", "Libdl"]
@@ -24,9 +53,9 @@ uuid = "e66e0078-7015-5450-92f7-15fbd957f2ae"
 
 [[deps.Configurations]]
 deps = ["ExproniconLite", "OrderedCollections", "TOML"]
-git-tree-sha1 = "b0dcafb34cfff977df79fc9927b70a9157a702ad"
+git-tree-sha1 = "79e812c535bb9780ba00f3acba526bde5652eb13"
 uuid = "5218b696-f38b-4ac9-8b61-a12ec717816d"
-version = "0.17.0"
+version = "0.16.6"
 
 [[deps.ConstructionBase]]
 deps = ["LinearAlgebra"]
@@ -121,10 +150,10 @@ uuid = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
 version = "1.4.1"
 
 [[deps.PackageCompiler]]
-deps = ["Artifacts", "LazyArtifacts", "Libdl", "Pkg", "Printf", "RelocatableFolders", "UUIDs"]
-git-tree-sha1 = "9d979ef195d8a2dc0e3ba409d6f624439edc4d26"
+deps = ["Artifacts", "LazyArtifacts", "Libdl", "Pkg", "RelocatableFolders", "UUIDs"]
+git-tree-sha1 = "a16924b37299cc7d6106fac255b44a8c79c7c21f"
 uuid = "9b87118b-4619-50d2-8e1e-99f35a4d4d9d"
-version = "2.0.4"
+version = "1.7.7"
 
 [[deps.Parameters]]
 deps = ["OrderedCollections", "UnPack"]

--- a/Manifest.toml
+++ b/Manifest.toml
@@ -14,9 +14,9 @@ uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 
 [[deps.Comonicon]]
 deps = ["Configurations", "ExproniconLite", "Libdl", "Logging", "Markdown", "PackageCompiler", "Pkg", "Scratch", "TOML", "UUIDs"]
-git-tree-sha1 = "c9f050be33ae132ff2b66a260010892dc54cfa9c"
+git-tree-sha1 = "c0a8d2369e6f1591d73aa418d6d58319913214ea"
 uuid = "863f3e99-da2a-4334-8734-de3dacbe5542"
-version = "0.12.1"
+version = "0.12.2"
 
 [[deps.CompilerSupportLibraries_jll]]
 deps = ["Artifacts", "Libdl"]
@@ -122,9 +122,9 @@ version = "1.4.1"
 
 [[deps.PackageCompiler]]
 deps = ["Artifacts", "LazyArtifacts", "Libdl", "Pkg", "Printf", "RelocatableFolders", "UUIDs"]
-git-tree-sha1 = "60792471fdfc90dfd047bb77a38a382aa23f9749"
+git-tree-sha1 = "9d979ef195d8a2dc0e3ba409d6f624439edc4d26"
 uuid = "9b87118b-4619-50d2-8e1e-99f35a4d4d9d"
-version = "2.0.3"
+version = "2.0.4"
 
 [[deps.Parameters]]
 deps = ["OrderedCollections", "UnPack"]
@@ -156,9 +156,9 @@ version = "0.1.3"
 
 [[deps.Requires]]
 deps = ["UUIDs"]
-git-tree-sha1 = "4036a3bd08ac7e968e27c203d45f5fff15020621"
+git-tree-sha1 = "8f82019e525f4d5c669692772a6f4b0a58b06a6a"
 uuid = "ae029012-a4dd-5104-9daa-d747884805df"
-version = "1.1.3"
+version = "1.2.0"
 
 [[deps.SHA]]
 uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TreeKnit"
 uuid = "03f602be-98a1-4bb2-9504-fbd3406624a7"
 authors = ["PierreBarrat <p.barrat@live.fr>"]
-version = "0.1.0"
+version = "0.1.1"
 
 [deps]
 Comonicon = "863f3e99-da2a-4334-8734-de3dacbe5542"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TreeKnit"
 uuid = "03f602be-98a1-4bb2-9504-fbd3406624a7"
 authors = ["PierreBarrat <p.barrat@live.fr>"]
-version = "0.1.1"
+version = "0.1.0"
 
 [deps]
 Comonicon = "863f3e99-da2a-4334-8734-de3dacbe5542"

--- a/Project.toml
+++ b/Project.toml
@@ -13,7 +13,7 @@ Setfield = "efcf1570-3423-57d1-acb7-fd33fddbac46"
 TreeTools = "62f0eae3-8c0e-4032-a621-7756092209e5"
 
 [compat]
-Comonicon = "0.12"
+Comonicon = "=0.11.7"
 LoggingExtras = "0.4"
 Parameters = "0.12"
 Setfield = "0.8"

--- a/deps/build.log
+++ b/deps/build.log
@@ -29,7 +29,7 @@
 │        @ ComoniconBuilder ~/.julia/packages/ComoniconBuilder/bJXHb/src/install.jl:3
 │     [12] install
 │        @ ~/.julia/packages/ComoniconBuilder/bJXHb/src/install.jl:2 [inlined]
-│     [13] #comonicon_install#82
+│     [13] #comonicon_install#77
 │        @ ~/.julia/packages/Comonicon/9x3SY/src/cast.jl:213 [inlined]
 │     [14] comonicon_install()
 │        @ TreeKnit ~/.julia/packages/Comonicon/9x3SY/src/cast.jl:213


### PR DESCRIPTION
Set Comonicon compat to v0.11.7
    
The v0.12 version uses the BASH_SOURCE variable (as recommended in the julia doc), but uses `#!/usr/bin/env sh` as a shebang, which points to dash.
Results in a "Bad substitution" error.