### PR TITLE
Update docs

### DIFF
--- a/docs/src/mccs.md
+++ b/docs/src/mccs.md
@@ -55,6 +55,5 @@ It is also possible to compute a "naive" estimation of MCCs using the `naive` ke
 using TreeKnit # hide
 t1 = node2tree(parse_newick("(((A1,A2),(B1,B2)),(C1,C2))"))
 t2 = node2tree(parse_newick("(((A1,A2),(C1,C2)),(B1,B2))"))
-trees = Dict(1=>t1, 2=>t2)
-computeMCCs(trees; naive=true)
+computeMCCs(t1, t2; naive=true)
 ```

--- a/docs/src/options.md
+++ b/docs/src/options.md
@@ -19,7 +19,6 @@ The example below illustrates the difference between different $\gamma$ values:
 using TreeKnit # hide
 t1 = node2tree(parse_newick("((((A,B),C),D),E)"))
 t2 = node2tree(parse_newick("((((D,B),E),A),C)")) # Same topology, but shuffled leaves
-trees = Dict(1=>t1, 2=>t2)
 nothing # hide
 ```
 Here, pruning the two leaves `(A,C)` or `(D,E)` results in compatible trees (resp. `((B,D),E)` and `((A,B),C)`). 
@@ -27,8 +26,8 @@ Here, pruning the two leaves `(A,C)` or `(D,E)` results in compatible trees (res
   They will only be accepted if $\gamma \leq 2.5$. 
 
 ```@repl gamma1
-  computeMCCs(trees, OptArgs(γ=2))[1,2]
-  computeMCCs(trees, OptArgs(γ=3))[1,2]
+  computeMCCs(t1, t2, OptArgs(γ=2))
+  computeMCCs(t1, t2, OptArgs(γ=3))
 ```
 
 
@@ -42,13 +41,12 @@ In the example below, there are three equivalent decompositions if only topology
 using TreeKnit # hide
 t1 = node2tree(parse_newick("((A:2,B:2):2,C:4)"))
 t2 = node2tree(parse_newick("(A:2,(B:1,C:1):1)"))
-trees = Dict(1=>t1, 2=>t2)
 oa = OptArgs(likelihood_sort = false)
-unique([computeMCCs(trees, oa)[1,2] for rep in 1:50]) # Repeating computation many times 
+unique([computeMCCs(t1, t2, oa) for rep in 1:50]) # Repeating computation many times 
 ```
 
 When taking branch lengths into account, this degeneracy vanishes: 
 ```@example degeneracy
 oa = OptArgs(likelihood_sort = true)
-unique([computeMCCs(trees, oa)[1,2] for rep in 1:50])
+unique([computeMCCs(t1, t2, oa) for rep in 1:50])
 ```

--- a/docs/src/opttrees.md
+++ b/docs/src/opttrees.md
@@ -140,9 +140,8 @@ For this simple example, $\gamma = 3$ is the "critical" value above which the fa
   In the second, three MCCs and three reassortments will be found. 
 
 ```@repl opttrees
-trees = Dict(1=>t1, 2=>t2);
-computeMCCs(trees, OptArgs(γ=3.1))[1,2]
-computeMCCs(trees, OptArgs(γ=2.9))[1,2]
+computeMCCs(t1, t2, OptArgs(γ=3.1))
+computeMCCs(t1, t2, OptArgs(γ=2.9))
 ```
 
 ## Simulated annealing 

--- a/docs/src/resolving.md
+++ b/docs/src/resolving.md
@@ -74,7 +74,7 @@ However, the topology-based heuristic used by *TreeKnit* is not able to detect t
   For instance, the split above `E` will be `(D,E)` in the first tree and `(C,D,E)` in the second. 
   Without resolving, the heuristic will predict a reassortment above almost every leaf: 
 ```@example 3
-computeMCCs(Dict(1 => t1, 2 => t2), OptArgs(;resolve=false))[1,2]
+computeMCCs(t1, t2, OptArgs(;resolve=false))
 ```
 
 In order to achieve progress in this kind of situation, we have to perform two operations at the same time: 
@@ -83,7 +83,7 @@ In order to achieve progress in this kind of situation, we have to perform two o
 
 This is done automatically during MCC inference if the `resolve` option of `OptArgs` is given (default):  
 ```@example 3
-MCCs = computeMCCs(Dict(1 => t1, 2 => t2), OptArgs(;resolve=true))[1,2]
+MCCs = computeMCCs(t1, t2, OptArgs(;resolve=true))
 ```
 
 ## Resolving with inferred MCCs


### PR DESCRIPTION
Functions like compute_mccs were still using dictionaries in the doc.