### PR TITLE
Fix/bad substitution

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -13,7 +13,7 @@ Setfield = "efcf1570-3423-57d1-acb7-fd33fddbac46"
 TreeTools = "62f0eae3-8c0e-4032-a621-7756092209e5"
 
 [compat]
-Comonicon = "=0.11.7"
+Comonicon = "0.12"
 LoggingExtras = "0.4"
 Parameters = "0.12"
 Setfield = "0.8"

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -20,5 +20,8 @@ Pkg.build("TreeKnit")
 
 This will add executable scripts to your `~/.julia/bin` folder. 
 Simply add this folder to your path to call the script, *e.g.* `export PATH="$HOME/.julia/bin:$PATH"`. 
-You should now be able to call, *e.g.*, `treeknit --help`.
+You should now be able to call, *e.g.*, `bash treeknit --help`.
+
+!!! warn
+    For now, the `treeknit` script should be called specifically with `bash`. I hope to remove this limitation in the future. 
 

--- a/docs/src/overview.md
+++ b/docs/src/overview.md
@@ -14,7 +14,7 @@ Inputs to `treeknit` are two files containing trees in Newick format.
 The only strict condition on the trees is that they share their leaf nodes. 
 Example: 
 ```
-treeknit tree1.nwk tree2.nwk
+bash treeknit tree1.nwk tree2.nwk
 ```
 
 !!! warning "Insignificant branches"


### PR DESCRIPTION
The CLI must be called using `bash`, *i.e.* `bash treeknit t1.nwk t2.nwk`. 
Documentation was changed to make that explicit. 