### PR TITLE
improve cooling schedule and parametrization of SA

### DIFF
--- a/src/cli.jl
+++ b/src/cli.jl
@@ -11,7 +11,7 @@ treeknit
 - `-o, --outdir <arg>`: directory for results; Example `-o=treeknit_results`
 - `-g, --gamma <arg>`: value of γ; Example `-g=2`
 - `--seq-lengths <arg>`: length of the sequences. Example: `--seq-length "1500 2000"`
-- `--n-sa-it <arg>`: number of SA iterations per temperature and per leaf; default 0.2
+- `--n-mcmc-it <arg>`: number of MCMC iterations per leaf; default 25
 
 # Flags
 
@@ -26,7 +26,7 @@ treeknit
 	outdir::AbstractString = "treeknit_results",
 	gamma::Float64 = 2.,
 	seq_lengths::AbstractString = "1 1",
-	n_sa_it::Float64 = 0.2,
+	n_mcmc_it::Int = 25,
 	# flags
 	naive::Bool = false,
 	no_likelihood::Bool = false,
@@ -74,7 +74,7 @@ treeknit
 		γ = gamma,
 		likelihood_sort = !no_likelihood,
 		resolve = !no_resolve,
-		Md = 1 / n_sa_it,
+		nMCMC = n_mcmc_it,
 		seq_lengths = sl,
 		verbose=true,
 	)

--- a/src/main.jl
+++ b/src/main.jl
@@ -89,7 +89,7 @@ function runopt(oa::OptArgs, t1::Tree, t2::Tree; output = :mccs)
 		# Topology based inference
 		oa.verbose && @info "Running optimization to find MCCs..."
 		@assert share_labels(ot1, ot2) "Trees do not share leaves"
-		M = getM(length(ot1.lleaves), oa.Md)
+		M = Int(ceil(length(ot1.lleaves) * oa.nMCMC / length(oa.Trange)))
 		mccs, Efinal, Ffinal, lk = SplitGraph.opttrees(
 			ot1, ot2;
 			γ=oa.γ, seq_lengths = oa.seq_lengths, M=M, Trange=oa.Trange,

--- a/src/objects.jl
+++ b/src/objects.jl
@@ -13,13 +13,11 @@ Storing parameters for `SplitGraph.runopt` function.
   Used in likelihood calculations.
   This is initialized from other input arguments, and defaults to sequences of length one.
 ### Simulated annealing
-- `Md::Real = 10`:  number of SA iterations (per temperature) for a tree of `n` leaves is
-  `ceil(Int, n/Md)`.
-- `cooling_schedule = :geometric`: type of cooling schedule `(:geometric, :linear)`
-- `Tmin::Float64 = 1e-3`: minimal temperature of SA.
-- `Tmax::Float64 = 1`: maximal temperature of SA.
-- `αT::Float64 = 0.95`: ratio between terms in the geometric cooling.
-- `dT::Float64 = 1e-2`: temperature step in the linear cooling.
+- `nMCMC::Int = 25`: The number of MCMC iterations for a tree of `n` leaves is `nMCMC*n`.
+- `cooling_schedule = :geometric`: type of cooling schedule `(:geometric, :linear, :acos)`
+- `Tmin::Float64 = 0.05`: minimal temperature of SA.
+- `Tmax::Float64 = 0.8`: maximal temperature of SA.
+- `nT::Int = 3000`: number of steps in the cooling schedule
 ### Verbosity
 - `verbose::Bool=false`: first level of verbosity
 - `vv::Bool = false`: second level of verbosity
@@ -31,36 +29,48 @@ Storing parameters for `SplitGraph.runopt` function.
 	resolve::Bool = true
 	seq_lengths::Vector{Int} = [1, 1]
 	# For the annealing
-	Md::Real = 5
-	Tmin::Float64 = 1e-3
-	Tmax::Float64 = 1.; @assert Tmax > Tmin
-	αT::Float64 = 0.95
-	dT::Float64 = 1e-2
-	cooling_schedule = :geometric
-	Trange = get_cooling_schedule(; Tmin, Tmax, dT, αT, type=cooling_schedule)
+	nMCMC::Int = 25
+	Tmin::Float64 = 0.05; @assert Tmin > 0
+	Tmax::Float64 = 0.8; @assert Tmax > Tmin
+	nT::Int = 3000
+	cooling_schedule = :linear
+	Trange = get_cooling_schedule(Tmin, Tmax, nT, type=cooling_schedule)
 	sa_rep::Int64 = 1
 	# Verbosity
 	verbose::Bool = false
 	vv::Bool = false
 end
 
-function get_cooling_schedule(;
-	Tmax=1., Tmin = 1e-3, dT = 1e-2, αT = 0.95, type=:geometric,
-)
+function get_cooling_schedule(Tmax, Tmin, nT; type=:geometric)
 	if type == :geometric
-		return get_geometric_cooling_schedule(Tmin, Tmax, αT)
+		return get_geometric_cooling_schedule(Tmin, Tmax, nT)
 	elseif type == :linear
-		return get_linear_cooling_schedule(Tmin, Tmax, dT)
+		return get_linear_cooling_schedule(Tmin, Tmax, nT)
+	elseif type == :acos
+		return get_acos_cooling_schedule(Tmin, Tmax, nT)
 	else
 		error("Unknown `cooling_schedule` field: $(type). See `?OptArgs` for allowed values.")
 	end
 end
 
-function get_geometric_cooling_schedule(Tmin, Tmax, αT)
-	n = ceil(Int, (log(Tmin) - log(Tmax)) / log(αT))
-	return [αT^i * Tmax for i in 0:n]
+function get_geometric_cooling_schedule(Tmin, Tmax, nT)
+	α = (log(Tmin) - log(Tmax)) / nT
+	n = ceil(Int, (log(Tmin) - log(Tmax)) / log(α))
+	return [α^i * Tmax for i in 0:n]
 end
 
-get_linear_cooling_schedule(Tmin, Tmax, dT) = return reverse(Tmin:dT:Tmax)
+function get_acos_cooling_schedule(Tmin, Tmax, nT)
+	f(x, K=1.5) = if x < 0.5
+		0.5 + 2^(K-1)*abs(acos(2*x-1)/3.14-0.5)^K
+	elseif x == 0.5
+		0.5
+	else
+		0.5 - 2^(K-1)*abs(acos(2*x-1)/3.14-0.5)^K
+	end
+	# f(0) = 1.0 and f(1) = 0.
+	return [(Tmax - Tmin)*f(t) + Tmin for t in range(0,1,nT)]
+end
+
+get_linear_cooling_schedule(Tmin, Tmax, nT) = return collect(reverse(range(Tmin, Tmax, nT)))
 
 


### PR DESCRIPTION
Change to cooling schedule:
- Default cooling schedule is now linear. Most changes in F happen in the region T ~ [0.2, 0.5], which does not play well with geometrical.
- New acos option for cooling schedule which spends more time in the interesting region. No improvement over linear on a simple test (simulated tree with 4000 leaves)
- Default temperature range: 0.8 --> 0.05

Parameters of the SA are now simpler:
- nT: number of steps in the cooling. Replaces dT and alphaT. Set by the n-mcmc-it option in the cli
- nMCMC: total number of MCMC steps per leaf, default 25. (25 * L / nT MCMC steps per temperature). Replaces Md