### PR TITLE
adapt to TreeTools 0.3.0

### DIFF
--- a/src/SplitGraph/SplitGraph.jl
+++ b/src/SplitGraph/SplitGraph.jl
@@ -42,7 +42,7 @@ function opttrees(t...;
 	verbose=false
 )
 	opttrees!(
-		γ, Trange, M, seq_lengths, [copy(x, TreeTools.EmptyData) for x in t]...;
+		γ, Trange, M, seq_lengths, [convert(Tree{TreeTools.EmptyData}, x) for x in t]...;
 		likelihood_sort, resolve, sa_rep, verbose
 	)
 end

--- a/src/SplitGraph/energy.jl
+++ b/src/SplitGraph/energy.jl
@@ -307,7 +307,7 @@ end
 	count_mismatches(t::Vararg{Tree})
 """
 function count_mismatches(trees::Vararg{Tree})
-	treelist = [copy(t, TreeTools.EmptyData) for t in trees]
+	treelist = [convert(Tree{TreeTools.EmptyData}, t) for t in trees]
 	mcc = naive_mccs(treelist)
 	mcc_names = TreeKnit.name_mcc_clades!(treelist, mcc)
 	for (i,t) in enumerate(treelist)

--- a/src/mcc_base.jl
+++ b/src/mcc_base.jl
@@ -194,7 +194,7 @@ end
 Reduce `tree` to its MCC by grouping leaves. Returns a tree with `length(MCC)` leaves.
 """
 function reduce_to_mcc(tree::Tree, MCC)
-    out = copy(tree, TreeTools.EmptyData)
+    out = copy(tree)
     reduce_to_mcc!(out, MCC)
     return out
 end


### PR DESCRIPTION
`copy(t::Tree)` changed. 