### PR TITLE
fix CLI to use resolve (not strict resolve) trees when converting to an ARG

### DIFF
--- a/src/cli.jl
+++ b/src/cli.jl
@@ -100,25 +100,30 @@ Should be of the form `--seq-lengths \"1500 2000\"`"
 	verbose && println()
 
 	@info "Resolving trees based on found MCCs..."
-	t1, t2, rS = resolve_strict(t1, t2, MCCs)
-	TreeTools.ladderize!(t1)
-	sort_polytomies_strict!(t1, t2, MCCs)
+	t1_strict, t2_strict, rS = resolve_strict(t1, t2, MCCs)
+	TreeTools.ladderize!(t1_strict)
+	sort_polytomies_strict!(t1_strict, t2_strict, MCCs)
 	@info "Resolved $(length(rS[1])) splits in $(nwk1) and $(length(rS[1])) splits in $(nwk2)\n"
 
 	verbose && println()
 
-	@info "Building ARG from trees and MCCs..."
-	arg, rlm, lm1, lm2 = SRG.arg_from_trees(t1, t2, MCCs)
-	@info "Found $(length(arg.hybrids)) reassortments in the ARG.\n"
-
-	verbose && println()
-
-	# Write output
+	# Write tree output
 	@info "Writing results in $(outdir)"
 	write_mccs(outdir * "/" * "MCCs.dat", MCCs)
 	out_nwk1, out_nwk2 = make_output_tree_names(nwk1, nwk2)
-	write_newick(outdir * "/" * out_nwk1, t1)
-	write_newick(outdir * "/" * out_nwk2, t2)
+	write_newick(outdir * "/" * out_nwk1, t1_strict)
+	write_newick(outdir * "/" * out_nwk2, t2_strict)
+
+	verbose && println()
+
+	@info "Building ARG from trees and MCCs..."
+	rS = resolve!(t1, t2, MCCs)
+	TreeTools.ladderize!(t1)
+	sort_polytomies!(t1, t2, MCCs)
+	arg, rlm, lm1, lm2 = SRG.arg_from_trees(t1, t2, MCCs)
+	@info "Found $(length(arg.hybrids)) reassortments in the ARG.\n"
+
+	# Write arg output
 	write(outdir * "/" * "arg.nwk", arg)
 	write_rlm(outdir * "/" * "nodes.dat", rlm)
 

--- a/test/treeknit_tests.sh
+++ b/test/treeknit_tests.sh
@@ -1,0 +1,21 @@
+julia --project=. deps/build.jl
+if [ $? -eq 0 ]; then
+    echo Installation OK
+else
+    echo Installation FAIL
+fi
+
+export PATH="$HOME/.julia/bin:$PATH"
+treeknit test/NYdata/tree_ha.nwk test/NYdata/tree_na.nwk
+if [ $? -eq 0 ]; then
+    echo CLI run OK
+else
+    echo CLI run FAIL
+fi
+
+julia --project=. test/runtests.jl 
+if [ $? -eq 0 ]; then
+    echo tests OK
+else
+    echo tests FAIL
+fi


### PR DESCRIPTION
I just realized that when that calling TreeKnit via the command line fails as `cli.jl` uses `strict_resolve` which converts trees to `MiscData` trees but `arg_from_trees` requires trees of the `EmptyData` type. 

```ERROR: LoadError: MethodError: Cannot `convert` an object of type 
  TreeTools.TreeNode{TreeTools.EmptyData} to an object of type 
  TreeTools.TreeNode{TreeTools.MiscData}```

We also discussed that for the ARG the old `resolve()` function is needed and we should only use strict resolve for outputting resolved trees so that these do not contain any inaccurate splits. 