### PR TITLE
Standardize resolve function: Allow strict resolve to work on all trees

### DIFF
--- a/src/cli.jl
+++ b/src/cli.jl
@@ -101,7 +101,7 @@ Should be of the form `--seq-lengths \"1500 2000\"`"
 
 	@info "Resolving trees based on found MCCs..."
 	t1_strict, t2_strict = copy(t1), copy(t2)
-	rS = resolve_strict!(t1_strict, t2_strict, MCCs)
+	rS = resolve!(t1_strict, t2_strict, MCCs; strict=true)
 	TreeTools.ladderize!(t1_strict)
 	sort_polytomies!(t1_strict, t2_strict, MCCs)
 	@info "Resolved $(length(rS[1])) splits in $(nwk1) and $(length(rS[1])) splits in $(nwk2)\n"

--- a/src/cli.jl
+++ b/src/cli.jl
@@ -100,7 +100,8 @@ Should be of the form `--seq-lengths \"1500 2000\"`"
 	verbose && println()
 
 	@info "Resolving trees based on found MCCs..."
-	t1_strict, t2_strict, rS = resolve_strict(t1, t2, MCCs)
+	t1_strict, t2_strict = copy(t1), copy(t2)
+	rS = resolve_strict!(t1_strict, t2_strict, MCCs)
 	TreeTools.ladderize!(t1_strict)
 	sort_polytomies!(t1_strict, t2_strict, MCCs)
 	@info "Resolved $(length(rS[1])) splits in $(nwk1) and $(length(rS[1])) splits in $(nwk2)\n"

--- a/src/resolving.jl
+++ b/src/resolving.jl
@@ -161,16 +161,8 @@ New branches have a length `tau`.
 Return the list of resolved splits in each tree.
 """
 
-function resolve!(t1::Tree{T}, t2::Tree{T}, MCCs; tau = 0.) where T 
-	resolvable_splits = TreeKnit.new_splits(MCCs, t1, t2)
-	resolve!(t1, resolvable_splits[1]; conflict=:fail, tau)
-	resolve!(t2, resolvable_splits[2]; conflict=:fail, tau)
-
-	return resolvable_splits
-end
-
-function resolve_strict!(t1::Tree{T}, t2::Tree{T}, MCCs; tau = 0.) where T 
-	resolvable_splits = TreeKnit.new_splits(MCCs, t1, t2; strict=true)
+function resolve!(t1::Tree{T}, t2::Tree{T}, MCCs; tau = 0., strict=false) where T 
+	resolvable_splits = TreeKnit.new_splits(MCCs, t1, t2; strict =strict)
 	resolve!(t1, resolvable_splits[1]; conflict=:fail, tau)
 	resolve!(t2, resolvable_splits[2]; conflict=:fail, tau)
 

--- a/src/resolving.jl
+++ b/src/resolving.jl
@@ -162,7 +162,7 @@ Return the list of resolved splits in each tree.
 """
 
 function resolve!(t1::Tree{T}, t2::Tree{T}, MCCs; tau = 0., strict=false) where T 
-	resolvable_splits = TreeKnit.new_splits(MCCs, t1, t2; strict =strict)
+	resolvable_splits = TreeKnit.new_splits(MCCs, t1, t2; strict)
 	resolve!(t1, resolvable_splits[1]; conflict=:fail, tau)
 	resolve!(t2, resolvable_splits[2]; conflict=:fail, tau)
 

--- a/src/resolving.jl
+++ b/src/resolving.jl
@@ -161,7 +161,7 @@ New branches have a length `tau`.
 Return the list of resolved splits in each tree.
 """
 
-function resolve!(t1::Tree, t2::Tree, MCCs; tau = 0.)
+function resolve!(t1::Tree{T}, t2::Tree{T}, MCCs; tau = 0.) where T 
 	resolvable_splits = TreeKnit.new_splits(MCCs, t1, t2)
 	resolve!(t1, resolvable_splits[1]; conflict=:fail, tau)
 	resolve!(t2, resolvable_splits[2]; conflict=:fail, tau)
@@ -169,26 +169,12 @@ function resolve!(t1::Tree, t2::Tree, MCCs; tau = 0.)
 	return resolvable_splits
 end
 
-function resolve_strict!(
-	t1::Tree{TreeTools.MiscData}, t2::Tree{TreeTools.MiscData}, MCCs; tau = 0.
-)
+function resolve_strict!(t1::Tree{T}, t2::Tree{T}, MCCs; tau = 0.) where T 
 	resolvable_splits = TreeKnit.new_splits(MCCs, t1, t2; strict=true)
 	resolve!(t1, resolvable_splits[1]; conflict=:fail, tau)
 	resolve!(t2, resolvable_splits[2]; conflict=:fail, tau)
 
 	return resolvable_splits
-end
-
-function resolve_strict(
-	t1_input::Tree{T}, t2_input::Tree{T}, MCCs; tau = 0.
-) where T
-	t1 = TreeTools.convert(Tree{TreeTools.MiscData}, t1_input)
-	t2 = TreeTools.convert(Tree{TreeTools.MiscData}, t2_input)
-	resolvable_splits = TreeKnit.new_splits(MCCs, t1, t2; strict=true)
-	resolve!(t1, resolvable_splits[1]; conflict=:fail, tau)
-	resolve!(t2, resolvable_splits[2]; conflict=:fail, tau)
-
-	return t1, t2, resolvable_splits
 end
 
 

--- a/test/NYdata/test.jl
+++ b/test/NYdata/test.jl
@@ -31,7 +31,7 @@ calling ladderize and sort_polytomies on the resolved trees. This will make sure
 lines between nodes in an MCC do not cross when The two trees are visualized as a dendrogram.
 """
 function check_sort_polytomies(t1, t2, MCCs) 
-	t1, t2, rS_strict = TreeKnit.resolve_strict(t1, t2, MCCs; tau = 0.)
+	rS_strict = TreeKnit.resolve_strict!(t1, t2, MCCs; tau = 0.)
 	TreeTools.ladderize!(t1)
 	TreeKnit.sort_polytomies!(t1, t2, MCCs)
 	leaf_map = map_mccs(MCCs)

--- a/test/NYdata/test.jl
+++ b/test/NYdata/test.jl
@@ -31,7 +31,7 @@ calling ladderize and sort_polytomies on the resolved trees. This will make sure
 lines between nodes in an MCC do not cross when The two trees are visualized as a dendrogram.
 """
 function check_sort_polytomies(t1, t2, MCCs) 
-	rS_strict = TreeKnit.resolve_strict!(t1, t2, MCCs; tau = 0.)
+	rS_strict = TreeKnit.resolve!(t1, t2, MCCs; tau = 0., strict=true)
 	TreeTools.ladderize!(t1)
 	TreeKnit.sort_polytomies!(t1, t2, MCCs)
 	leaf_map = map_mccs(MCCs)
@@ -67,7 +67,7 @@ function check_sort_polytomies(t1, t2, MCCs)
 	return sorted
 end
 
-@testset "sort_polytomies! on resolve_strict! NY trees" begin
+@testset "sort_polytomies! on strict resolve! NY trees" begin
 	@test check_sort_polytomies(t1, t2, MCCs)
 end
 

--- a/test/resolving/test.jl
+++ b/test/resolving/test.jl
@@ -160,19 +160,12 @@ MCCs = TreeKnit.sort([["A","B","C"],["D","E","X"]], lt=TreeKnit.clt)
 	
 	t1_copy = copy(t1)
 	t2_copy = copy(t2)
-	t1_copy, t2_copy, rS = TreeKnit.resolve_strict(t1_copy, t2_copy, MCCs; tau = 0.)
+	rS = TreeKnit.resolve_strict!(t1_copy, t2_copy, MCCs; tau = 0.)
 	@test write_newick(t1_copy.root) == "((D,E,((A,B)RESOLVED_1:0.0,C)RESOLVED_2:0.0)NODE_2,X)NODE_1:0;"
 	
-	t1_copy_inplace = copy(t1)
-	t2_copy_inplace = copy(t2)
-	rS = TreeKnit.resolve_strict!(t1_copy_inplace, t2_copy_inplace, MCCs; tau = 0.)
-	@test (t1_copy_inplace.label, t2_copy_inplace.label) == (t1_copy.label, t2_copy.label)
-	@test write_newick(t1_copy.root) == write_newick(t1_copy_inplace.root)
-	
-	##check ladderize works the same
+	##check ladderize works the same for strict resolve
 	TreeTools.ladderize!(t1_copy)
-	TreeTools.ladderize!(t1_copy_inplace) 
-	@test write_newick(t1_copy_inplace.root) == write_newick(t1_copy.root) =="(X,(D,E,(C,(A,B)RESOLVED_1:0.0)RESOLVED_2:0.0)NODE_2)NODE_1:0;"
+	@test write_newick(t1_copy.root) =="(X,(D,E,(C,(A,B)RESOLVED_1:0.0)RESOLVED_2:0.0)NODE_2)NODE_1:0;"
 end
 
 t1_empty = node2tree(TreeTools.parse_newick(nwk_1; node_data_type=TreeTools.EmptyData); label="t1_empty")
@@ -187,7 +180,7 @@ t2_empty = node2tree(TreeTools.parse_newick(nwk_2; node_data_type=TreeTools.Empt
 	
 	t1_copy = copy(t1_empty)
 	t2_copy = copy(t2_empty)
-	t1_copy, t2_copy, rS = TreeKnit.resolve_strict(t1_copy, t2_copy, MCCs; tau = 0.)
+	rS = TreeKnit.resolve_strict!(t1_copy, t2_copy, MCCs; tau = 0.)
 	@test (t1_copy.label, t2_copy.label) == ("t1_empty", "t2_empty")
 	@test write_newick(t1_copy.root) == "((D,E,((A,B)RESOLVED_1:0.0,C)RESOLVED_2:0.0)NODE_2,X)NODE_1:0;"
 	

--- a/test/resolving/test.jl
+++ b/test/resolving/test.jl
@@ -160,7 +160,7 @@ MCCs = TreeKnit.sort([["A","B","C"],["D","E","X"]], lt=TreeKnit.clt)
 	
 	t1_copy = copy(t1)
 	t2_copy = copy(t2)
-	rS = TreeKnit.resolve_strict!(t1_copy, t2_copy, MCCs; tau = 0.)
+	rS = TreeKnit.resolve!(t1_copy, t2_copy, MCCs; tau = 0., strict=true)
 	@test write_newick(t1_copy.root) == "((D,E,((A,B)RESOLVED_1:0.0,C)RESOLVED_2:0.0)NODE_2,X)NODE_1:0;"
 	
 	##check ladderize works the same for strict resolve
@@ -180,7 +180,7 @@ t2_empty = node2tree(TreeTools.parse_newick(nwk_2; node_data_type=TreeTools.Empt
 	
 	t1_copy = copy(t1_empty)
 	t2_copy = copy(t2_empty)
-	rS = TreeKnit.resolve_strict!(t1_copy, t2_copy, MCCs; tau = 0.)
+	rS = TreeKnit.resolve!(t1_copy, t2_copy, MCCs; tau = 0., strict=true)
 	@test (t1_copy.label, t2_copy.label) == ("t1_empty", "t2_empty")
 	@test write_newick(t1_copy.root) == "((D,E,((A,B)RESOLVED_1:0.0,C)RESOLVED_2:0.0)NODE_2,X)NODE_1:0;"
 	
@@ -207,7 +207,7 @@ MCCs = TreeKnit.sort([["A","B","C"],["D","E","X"]], lt=TreeKnit.clt)
 	
 	t1_strict = copy(t1)
 	t2_strict = copy(t2)
-	rS_strict = TreeKnit.resolve_strict!(t1_strict, t2_strict, MCCs; tau = 0.)
+	rS_strict = TreeKnit.resolve!(t1_strict, t2_strict, MCCs; tau = 0., strict=true)
 	TreeTools.ladderize!(t1_strict)
 	TreeKnit.sort_polytomies!(t1_strict, t2_strict, MCCs)
 
@@ -227,7 +227,7 @@ MCCs = TreeKnit.sort([["B"], ["A","C","D","E"]], lt=TreeKnit.clt)
 @testset "check sort_polytomies! works when internal node could belong to more than one mcc" begin
 	t1_strict = copy(t1)
 	t2_strict = copy(t2)
-	rS_strict = TreeKnit.resolve_strict!(t1_strict, t2_strict, MCCs; tau = 0.)
+	rS_strict = TreeKnit.resolve!(t1_strict, t2_strict, MCCs; tau = 0., strict=true)
 	TreeTools.ladderize!(t1_strict)
 	TreeKnit.sort_polytomies!(t1_strict, t2_strict, MCCs)
 	@test write_newick(t1_strict.root) == "(A,(B,C,D,E)NODE_2)NODE_1:0;"
@@ -235,7 +235,7 @@ MCCs = TreeKnit.sort([["B"], ["A","C","D","E"]], lt=TreeKnit.clt)
 
 	t1_strict = copy(t1)
 	t2_strict = copy(t2)
-	rS_strict = TreeKnit.resolve_strict!(t2_strict, t1_strict, MCCs; tau = 0.)
+	rS_strict = TreeKnit.resolve!(t2_strict, t1_strict, MCCs; tau = 0., strict=true)
 	TreeTools.ladderize!(t2_strict)
 	TreeKnit.sort_polytomies!(t2_strict, t1_strict, MCCs)
 	@test write_newick(t1_strict.root) == "(A,(E,C,D,B)NODE_2)NODE_1:0;"


### PR DESCRIPTION
Up until now the `resolve_strict!` function could only work on MiscData Trees, but as https://github.com/PierreBarrat/TreeKnit.jl/pull/27  has fixed this I removed this dependency and also tidied up the `_map_split_to_tree!` function a bit so that it is easier to read. I additionally change the naming to only have one `resolve!` function (I removed `resolve_strict!`) with a `strict` parameter. 