### PR TITLE
Fix/sort polytomies strict

### DIFF
--- a/src/cli.jl
+++ b/src/cli.jl
@@ -103,7 +103,7 @@ Should be of the form `--seq-lengths \"1500 2000\"`"
 	t1_strict, t2_strict = copy(t1), copy(t2)
 	rS = resolve!(t1_strict, t2_strict, MCCs; strict=true)
 	TreeTools.ladderize!(t1_strict)
-	sort_polytomies!(t1_strict, t2_strict, MCCs)
+	sort_polytomies!(t1_strict, t2_strict, MCCs; strict=true)
 	@info "Resolved $(length(rS[1])) splits in $(nwk1) and $(length(rS[1])) splits in $(nwk2)\n"
 
 	verbose && println()

--- a/src/mcc_tools.jl
+++ b/src/mcc_tools.jl
@@ -171,11 +171,17 @@ Sort nodes of `t2` such that leaves of `t1` and `t2` in the same MCC face each o
 In a tanglegram with nodes colored according to MCC, lines of the same color will not cross.
 The order of `t1` serves as a guide and is left unchanged.
 """
-function sort_polytomies!(t1::Tree{T}, t2::Tree{T}, MCCs) where T
+function sort_polytomies!(t1::Tree{T}, t2::Tree{T}, MCCs; strict=false) where T
 	mcc_order = get_leaves_order(t1, MCCs)
 	_mcc_map = map_mccs(t2, MCCs)
 	sort_polytomies!(t2.root, MCCs, _mcc_map, mcc_order)
 	node2tree!(t2, t2.root)
+	if strict # when using strict resolve the more resolved tree always has to be used as the first tree
+		mcc_order = get_leaves_order(t2, MCCs)
+		_mcc_map = map_mccs(t1, MCCs)
+		sort_polytomies!(t1.root, MCCs, _mcc_map, mcc_order)
+		node2tree!(t1, t1.root)
+	end
 	return nothing
 end
 
@@ -226,6 +232,71 @@ function _sort_children!(n, rank)
 	children_order = sortperm(rank, lt = _isless)
 	n.child = n.child[children_order]
 end
+
+# """
+# 	sort_polytomies!(t1::Tree, t2::Tree, MCCs)
+
+# Sort nodes of `t2` such that leaves of `t1` and `t2` in the same MCC face each other.
+# In a tanglegram with nodes colored according to MCC, lines of the same color will not cross.
+# The order of `t1` serves as a guide and is left unchanged.
+# """
+# function sort_polytomies!(t1::Tree{T}, t2::Tree{T}, MCCs; strict=false) where T
+# 	inner_mcc_order = get_leaves_order(t1, MCCs)
+# 	_mcc_map_t1 = map_mccs(t1, MCCs; internals=false)
+# 	mcc_order = unique!([_mcc_map_t1[n.label] for n in POTleaves(t1)])
+# 	_mcc_map_t2 = map_mccs(t2, MCCs)
+# 	sort_polytomies!(t2.root, MCCs, _mcc_map_t2, mcc_order, inner_mcc_order)
+# 	node2tree!(t2, t2.root)
+# 	if strict # when using strict resolve the more resolved tree always has to be used as the first tree
+# 		inner_mcc_order = get_leaves_order(t2, MCCs)
+# 		_mcc_map_t2 = map_mccs(t2, MCCs; internals=false)
+# 		mcc_order = unique!([_mcc_map_t2[n.label] for n in POTleaves(t2)])
+# 		_mcc_map_t1 = map_mccs(t1, MCCs)
+# 		sort_polytomies!(t1.root, MCCs, _mcc_map_t1, mcc_order, inner_mcc_order)
+# 		node2tree!(t1, t1.root)
+# 	end
+# 	return nothing
+# end
+
+# function sort_polytomies!(n::TreeNode, MCCs, mcc_map, mcc_order, inner_mcc_order)
+# 	if n.isleaf
+# 		i = mcc_map[n.label] # in MCCs[i]
+# 		return inner_mcc_order[i][n.label], mcc_order[i]  # rank in the polytomy, rank of mcc
+# 	else
+# 		i = mcc_map[n.label] # Id of the current MCC (can be `nothing`)
+
+# 		# Construct ranking or children
+# 		# positive if they are in same MCC as current node, negative otherwise
+# 		# r = 1
+# 		rank = Array{Any}(undef, length(n.child))
+# 		for (k, c) in enumerate(n.child)
+# 			rank[k] = sort_polytomies!(c, MCCs, mcc_map, mcc_order, inner_mcc_order)
+# 		end
+
+# 		# # Sort children
+# 		_sort_children!(n, rank)
+
+# 		# # Return minimum value of the rank of nodes in the MCC.
+# 		# # Will be used by parent to rank the current node
+# 		return findmin(r -> r[1], rank)[1], findmin(r -> r[2], rank)[1]
+# 	end
+# end
+
+# function _sort_children!(n, rank)
+# 	# Custom sorting function
+# 	## if the nodes are in the same MCC, rank them according to that
+# 	## otherwise, rank according to ladder rank (biggest clade at the beginning)
+# 	function _isless(x,y)
+# 		if x[2] == y[2] ## if in same mcc_
+# 			return x[1] < y[1] # those two numbers can't be equal (rank in mcc)
+# 		else
+# 			return x[2] < y[2]
+# 		end
+# 	end
+
+# 	children_order = sortperm(rank, lt = _isless)
+# 	n.child = n.child[children_order]
+# end
 
 
 

--- a/src/mcc_tools.jl
+++ b/src/mcc_tools.jl
@@ -163,7 +163,6 @@ function _get_leaves_order!(order::Dict, n::TreeNode, mcc::Vector{<:AbstractStri
 
 end
 
-
 """
 	sort_polytomies!(t1::Tree, t2::Tree, MCCs)
 
@@ -172,17 +171,44 @@ In a tanglegram with nodes colored according to MCC, lines of the same color wil
 The order of `t1` serves as a guide and is left unchanged.
 """
 function sort_polytomies!(t1::Tree{T}, t2::Tree{T}, MCCs; strict=false) where T
-	mcc_order = get_leaves_order(t1, MCCs)
-	_mcc_map = map_mccs(t2, MCCs)
-	sort_polytomies!(t2.root, MCCs, _mcc_map, mcc_order)
-	node2tree!(t2, t2.root)
-	if strict # when using strict resolve the more resolved tree always has to be used as the first tree
-		mcc_order = get_leaves_order(t2, MCCs)
-		_mcc_map = map_mccs(t1, MCCs)
-		sort_polytomies!(t1.root, MCCs, _mcc_map, mcc_order)
-		node2tree!(t1, t1.root)
+	if strict 
+		##create a copy of the trees which are then fully resolved so that they can be sorted correctly
+		t1_, t2_ = copy(t1), copy(t2)
+		resolve!(t1_, t2_, MCCs; strict=false)
+		TreeTools.ladderize!(t1_)
+		sort_polytomies!(t1_, t2_, MCCs)
+		##get order of leaves in sorted liberal resolved trees and apply this order to strict resolved trees
+		fixed_order_1 =  Dict(n.label => i for (i,n) in enumerate(POTleaves(t1_)))
+		fixed_order_2 =   Dict(n.label => i for (i,n) in enumerate(POTleaves(t2_)))
+		sort_polytomies!(t1.root, fixed_order_1)
+		sort_polytomies!(t2.root, fixed_order_2)
+		return nothing
+	else
+		mcc_order = get_leaves_order(t1, MCCs)
+		_mcc_map = map_mccs(t2, MCCs)
+		sort_polytomies!(t2.root, MCCs, _mcc_map, mcc_order)
+		node2tree!(t2, t2.root)
 	end
 	return nothing
+end
+
+function sort_polytomies!(n::TreeNode, fixed_order)
+	if n.isleaf
+		return fixed_order[n.label]
+	else
+		# # Sort children
+		rank = Array{Any}(undef, length(n.child))
+		for (k, c) in enumerate(n.child)
+			rank[k] = sort_polytomies!(c, fixed_order)
+		end
+	
+		children_order = sortperm(rank)
+		n.child = n.child[children_order]
+
+		# # Return minimum value of the rank of nodes in the MCC.
+		# # Will be used by parent to rank the current node
+		return findmin(r -> r[1], rank)[1]
+	end
 end
 
 function sort_polytomies!(n::TreeNode, MCCs, mcc_map, mcc_order)
@@ -232,71 +258,6 @@ function _sort_children!(n, rank)
 	children_order = sortperm(rank, lt = _isless)
 	n.child = n.child[children_order]
 end
-
-# """
-# 	sort_polytomies!(t1::Tree, t2::Tree, MCCs)
-
-# Sort nodes of `t2` such that leaves of `t1` and `t2` in the same MCC face each other.
-# In a tanglegram with nodes colored according to MCC, lines of the same color will not cross.
-# The order of `t1` serves as a guide and is left unchanged.
-# """
-# function sort_polytomies!(t1::Tree{T}, t2::Tree{T}, MCCs; strict=false) where T
-# 	inner_mcc_order = get_leaves_order(t1, MCCs)
-# 	_mcc_map_t1 = map_mccs(t1, MCCs; internals=false)
-# 	mcc_order = unique!([_mcc_map_t1[n.label] for n in POTleaves(t1)])
-# 	_mcc_map_t2 = map_mccs(t2, MCCs)
-# 	sort_polytomies!(t2.root, MCCs, _mcc_map_t2, mcc_order, inner_mcc_order)
-# 	node2tree!(t2, t2.root)
-# 	if strict # when using strict resolve the more resolved tree always has to be used as the first tree
-# 		inner_mcc_order = get_leaves_order(t2, MCCs)
-# 		_mcc_map_t2 = map_mccs(t2, MCCs; internals=false)
-# 		mcc_order = unique!([_mcc_map_t2[n.label] for n in POTleaves(t2)])
-# 		_mcc_map_t1 = map_mccs(t1, MCCs)
-# 		sort_polytomies!(t1.root, MCCs, _mcc_map_t1, mcc_order, inner_mcc_order)
-# 		node2tree!(t1, t1.root)
-# 	end
-# 	return nothing
-# end
-
-# function sort_polytomies!(n::TreeNode, MCCs, mcc_map, mcc_order, inner_mcc_order)
-# 	if n.isleaf
-# 		i = mcc_map[n.label] # in MCCs[i]
-# 		return inner_mcc_order[i][n.label], mcc_order[i]  # rank in the polytomy, rank of mcc
-# 	else
-# 		i = mcc_map[n.label] # Id of the current MCC (can be `nothing`)
-
-# 		# Construct ranking or children
-# 		# positive if they are in same MCC as current node, negative otherwise
-# 		# r = 1
-# 		rank = Array{Any}(undef, length(n.child))
-# 		for (k, c) in enumerate(n.child)
-# 			rank[k] = sort_polytomies!(c, MCCs, mcc_map, mcc_order, inner_mcc_order)
-# 		end
-
-# 		# # Sort children
-# 		_sort_children!(n, rank)
-
-# 		# # Return minimum value of the rank of nodes in the MCC.
-# 		# # Will be used by parent to rank the current node
-# 		return findmin(r -> r[1], rank)[1], findmin(r -> r[2], rank)[1]
-# 	end
-# end
-
-# function _sort_children!(n, rank)
-# 	# Custom sorting function
-# 	## if the nodes are in the same MCC, rank them according to that
-# 	## otherwise, rank according to ladder rank (biggest clade at the beginning)
-# 	function _isless(x,y)
-# 		if x[2] == y[2] ## if in same mcc_
-# 			return x[1] < y[1] # those two numbers can't be equal (rank in mcc)
-# 		else
-# 			return x[2] < y[2]
-# 		end
-# 	end
-
-# 	children_order = sortperm(rank, lt = _isless)
-# 	n.child = n.child[children_order]
-# end
 
 
 

--- a/test/NYdata/test.jl
+++ b/test/NYdata/test.jl
@@ -67,14 +67,4 @@ TreeKnit.sort_polytomies!(t1, t2, MCCs; strict=true)
 	@test check_sort_polytomies(t1, t2, MCCs)
 end
 
-t1 = node2tree(TreeTools.parse_newick("((A,B1),B2,C,D)"))
-t2 = node2tree(TreeTools.parse_newick("((A,B1,B2,D),C)"))
-MCCs = [["D"], ["A", "B1", "B2", "C"]]
-rS_strict = TreeKnit.resolve!(t1, t2, MCCs; tau = 0., strict=true)
-TreeTools.ladderize!(t1)
-TreeKnit.sort_polytomies!(t1, t2, MCCs; strict=true)
-@testset "sort_polytomies! on strict resolve! trees" begin
-	@test check_sort_polytomies(t1, t2, MCCs)
-end
-
 

--- a/test/NYdata/test.jl
+++ b/test/NYdata/test.jl
@@ -28,38 +28,31 @@ end
 		
 Check that leaves in the same MCC are in the same order in tree1 and tree2 after 
 calling ladderize and sort_polytomies on the resolved trees. This will make sure that 
-lines between nodes in an MCC do not cross when The two trees are visualized as a dendrogram.
+lines between nodes in an MCC do not cross when the two trees are visualized as a tanglegram.
 """
 function check_sort_polytomies(t1, t2, MCCs) 
-	rS_strict = TreeKnit.resolve!(t1, t2, MCCs; tau = 0., strict=true)
-	TreeTools.ladderize!(t1)
-	TreeKnit.sort_polytomies!(t1, t2, MCCs)
-	leaf_map = map_mccs(MCCs)
+	leaf_map = map_mccs(MCCs) ##map from leaf to mcc
 	pos_in_mcc_t1 = Dict()
-	pos = 1
 	for leaf in POTleaves(t1)
 		if haskey(pos_in_mcc_t1, leaf_map[leaf.label])
-			append!(pos_in_mcc_t1[leaf_map[leaf.label]], pos)
+			push!(pos_in_mcc_t1[leaf_map[leaf.label]], leaf.label)
 		else
-			pos_in_mcc_t1[leaf_map[leaf.label]] = [pos]
+			pos_in_mcc_t1[leaf_map[leaf.label]] = [leaf.label]
 		end
-		pos +=1 
 	end
 
 	pos_in_mcc_t2 = Dict()
-	pos = 1
 	for leaf in POTleaves(t2)
 		if haskey(pos_in_mcc_t2, leaf_map[leaf.label])
-			append!(pos_in_mcc_t2[leaf_map[leaf.label]], pos)
+			push!(pos_in_mcc_t2[leaf_map[leaf.label]], leaf.label)
 		else
-			pos_in_mcc_t2[leaf_map[leaf.label]] = [pos]
+			pos_in_mcc_t2[leaf_map[leaf.label]] = [leaf.label]
 		end
-		pos +=1 
 	end
 
 	sorted = true
 	for mcc in 1:length(MCCs)
-		if (sort(pos_in_mcc_t1[mcc]) !=  pos_in_mcc_t1[mcc]) || (sort(pos_in_mcc_t2[mcc]) !=  pos_in_mcc_t2[mcc])
+		if (pos_in_mcc_t1[mcc] != pos_in_mcc_t2[mcc])
 			sorted = false
 			break
 		end
@@ -67,7 +60,21 @@ function check_sort_polytomies(t1, t2, MCCs)
 	return sorted
 end
 
+rS_strict = TreeKnit.resolve!(t1, t2, MCCs; tau = 0., strict=true)
+TreeTools.ladderize!(t1)
+TreeKnit.sort_polytomies!(t1, t2, MCCs; strict=true)
 @testset "sort_polytomies! on strict resolve! NY trees" begin
 	@test check_sort_polytomies(t1, t2, MCCs)
 end
+
+t1 = node2tree(TreeTools.parse_newick("((A,B1),B2,C,D)"))
+t2 = node2tree(TreeTools.parse_newick("((A,B1,B2,D),C)"))
+MCCs = [["D"], ["A", "B1", "B2", "C"]]
+rS_strict = TreeKnit.resolve!(t1, t2, MCCs; tau = 0., strict=true)
+TreeTools.ladderize!(t1)
+TreeKnit.sort_polytomies!(t1, t2, MCCs; strict=true)
+@testset "sort_polytomies! on strict resolve! trees" begin
+	@test check_sort_polytomies(t1, t2, MCCs)
+end
+
 

--- a/test/resolving/test.jl
+++ b/test/resolving/test.jl
@@ -156,16 +156,16 @@ MCCs = TreeKnit.sort([["A","B","C"],["D","E","X"]], lt=TreeKnit.clt)
 	t1_copy = copy(t1)
 	t2_copy = copy(t2)
 	rS = resolve!(t1_copy, t2_copy, MCCs; tau = 0.)
-	@test write_newick(t1_copy.root) == "((((A,B)RESOLVED_1:0.0,C)RESOLVED_2:0.0,(D,E)RESOLVED_3:0.0)NODE_2,X)NODE_1:0;"
+	@test write_newick(t1_copy) == "((((A,B)RESOLVED_1:0.0,C)RESOLVED_2:0.0,(D,E)RESOLVED_3:0.0)NODE_2,X)NODE_1:0;"
 	
 	t1_copy = copy(t1)
 	t2_copy = copy(t2)
 	rS = TreeKnit.resolve!(t1_copy, t2_copy, MCCs; tau = 0., strict=true)
-	@test write_newick(t1_copy.root) == "((D,E,((A,B)RESOLVED_1:0.0,C)RESOLVED_2:0.0)NODE_2,X)NODE_1:0;"
+	@test write_newick(t1_copy) == "((D,E,((A,B)RESOLVED_1:0.0,C)RESOLVED_2:0.0)NODE_2,X)NODE_1:0;"
 	
 	##check ladderize works the same for strict resolve
 	TreeTools.ladderize!(t1_copy)
-	@test write_newick(t1_copy.root) =="(X,(D,E,(C,(A,B)RESOLVED_1:0.0)RESOLVED_2:0.0)NODE_2)NODE_1:0;"
+	@test write_newick(t1_copy) =="(X,(D,E,(C,(A,B)RESOLVED_1:0.0)RESOLVED_2:0.0)NODE_2)NODE_1:0;"
 end
 
 
@@ -191,8 +191,8 @@ MCCs = TreeKnit.sort([["A","B","C"],["D","E","X"]], lt=TreeKnit.clt)
 	TreeKnit.sort_polytomies!(t1_strict, t2_strict, MCCs; strict=true)
 
 	@test rS == rS_strict
-	@test write_newick(t1_copy.root) == write_newick(t1_strict.root)
-	@test write_newick(t2_copy.root) == write_newick(t2_strict.root)
+	@test write_newick(t1_copy) == write_newick(t1_strict)
+	@test write_newick(t2_copy) == write_newick(t2_strict)
 end
 
 nwk_1 = "(A,(C,D,E,B))"


### PR DESCRIPTION
## Issue
I realized that the `sort_polytomies` function is not properly working on trees that have been resolved using strict resolve. The test function that I had for checking `sort_polytomies` on the NY data set was also inaccurate. I initially wanted to modify the sorting algorithm but as that is quite challenging, I have now opted for resolving the tree using liberal resolve, sorting the polytomies and then applying this ordering to the strictly resolved trees. Thus, if the trees are resolved using strict resolve `sort_polytomies` should be called using the parameter `strict=true`. 

## Testing
Examples of where `sort_polytomies` breaks on strictly resolved trees can be found in the `test/resolving/test.jl` file at the very end. I have also tidied up this file a bit.  

