### PR TITLE
Fix error with CLI when specifying the gamma parameter value by reverting type of gamma parameter from Real to Float64

### DIFF
--- a/src/cli.jl
+++ b/src/cli.jl
@@ -37,7 +37,7 @@ We suggest two sets of defaults for running TreeKnit. `--better-trees` will prod
 	nwk_file1::AbstractString, nwk_file2::AbstractString, nwk_files::AbstractString...;
 	# options
 	outdir::AbstractString = "treeknit_results",
-	gamma::Real = OptArgs().γ,
+	gamma::Float64 = OptArgs().γ,
 	seq_lengths::AbstractString = join([string(i) for i in repeat([1], 2+ length(nwk_files))], " "),
 	n_mcmc_it::Int = OptArgs().nMCMC,
 	rounds::Int = 1,

--- a/test/command_line_tests.sh
+++ b/test/command_line_tests.sh
@@ -12,7 +12,7 @@ else
 fi 
 
 export PATH="$HOME/.julia/bin:$PATH"
-treeknit test/NYdata/tree_ha.nwk test/NYdata/tree_na.nwk --auspice-view
+treeknit test/NYdata/tree_ha.nwk test/NYdata/tree_na.nwk --auspice-view --gamma 2
 OUT=$?
 if [ "$OUT" != 0 ]; then
     rm -r treeknit_results


### PR DESCRIPTION
## Background

I’m running the latest version of TreeKnit (v0.5.5) with Julia 1.9.3 on an ARM64 Mac and I get the following error when I try to specify a gamma value:

```
$ ~/.julia/bin/treeknit rooted_tree_raw_ha.nwk rooted_tree_raw_na.nwk --gamma 2.5
ERROR: LoadError: MethodError: no method matching tryparse(::Type{Real}, ::String)

Closest candidates are:
  tryparse(::Type{T}, ::AbstractString) where T<:Dates.TimeType
   @ Dates /opt/homebrew/Cellar/julia/1.9.3/share/julia/stdlib/v1.9/Dates/src/parse.jl:290
  tryparse(::Type{T}, ::AbstractString, ::Dates.DateFormat) where T<:Dates.TimeType
   @ Dates /opt/homebrew/Cellar/julia/1.9.3/share/julia/stdlib/v1.9/Dates/src/parse.jl:290
  tryparse(::Type{Complex{S}}, ::AbstractString) where S<:Real
   @ Base parse.jl:389
  ...

Stacktrace:
 [1] command_main(ARGS::Vector{String})
   @ TreeKnit ~/.julia/scratchspaces/03f602be-98a1-4bb2-9504-fbd3406624a7/sysimg/libtreeknit.dylib:-1
 [2] command_main()
   @ TreeKnit ~/.julia/packages/Comonicon/AXDxW/src/codegen/julia.jl:90
 [3] top-level scope
   @ ~/.julia/bin/treeknit:15
 [4] include_string(mapexpr::typeof(identity), mod::Module, code::String, filename::String)
   @ Base ~/.julia/scratchspaces/03f602be-98a1-4bb2-9504-fbd3406624a7/sysimg/libtreeknit.dylib:-1
 [5] _include(mapexpr::Function, mod::Module, _path::String)
   @ Base ~/.julia/scratchspaces/03f602be-98a1-4bb2-9504-fbd3406624a7/sysimg/libtreeknit.dylib:-1
 [6] include(mod::Module, _path::String)
   @ Base ~/.julia/scratchspaces/03f602be-98a1-4bb2-9504-fbd3406624a7/sysimg/libtreeknit.dylib:-1
 [7] exec_options(opts::Base.JLOptions)
   @ Base ~/.julia/scratchspaces/03f602be-98a1-4bb2-9504-fbd3406624a7/sysimg/libtreeknit.dylib:-1
 [8] _start()
   @ Base ~/.julia/scratchspaces/03f602be-98a1-4bb2-9504-fbd3406624a7/sysimg/libtreeknit.dylib:-1
in expression starting at /Users/jhuddlesfredhutch.org/.julia/bin/treeknit:15
```

I get the same error when I pass an integer value for gamma.

I confirmed that the built-in `tryparse` method fails on the Julia REPL with:

```julia
tryparse(Real, "2")
```

The following works as expected, though:

```julia
julia> tryparse(Float64, "2")
2.0
```

The error in TreeKnit seemed to trace back to [this type change in version 0.5.5](https://github.com/PierreBarrat/TreeKnit.jl/commit/eba895b73b8357a4d00c5300f9422e54fd09c627) (after version 0.5.0). I tried downgrading TreeKnit to 0.5.0, but this did not fix the error.

## Proposed changes

[I forked the TreeKnit repo](https://github.com/huddlej/TreeKnit.jl/pull/1) (here), [modified the CLI test to run with the gamma argument](https://github.com/huddlej/TreeKnit.jl/pull/1/commits/0f3255a6ab4910dc1faf1daabb4040be982428c0), and confirmed that [the CI fails with the same error](https://github.com/huddlej/TreeKnit.jl/actions/runs/6163417479/job/16726915772#step:5:39). Then I tried [reverting the type from Real to Float64](https://github.com/huddlej/TreeKnit.jl/pull/1/commits/0b19dffac0cd4d525532ce74267fc577ac0891f0) and [confirmed that this change fixed the error](https://github.com/huddlej/TreeKnit.jl/actions/runs/6163506536/job/16727177216?pr=1#step:5:42). I also compiled TreeKnit locally and confirmed that the type reversion fixed my issue, allowing me to pass integer and floating point values.

## Testing

 - [x] Modified CLI test to run with `--gamma`, confirmed test failed prior to fix and passed after fix