### PR TITLE
fix default gamma value error in command line interface

### DIFF
--- a/src/cli.jl
+++ b/src/cli.jl
@@ -3,7 +3,7 @@
 
 # Intro
 
-We suggest two sets of defaults for running TreeKnit. `--better-trees` will produce more accurately resolved trees (default for more than two trees). If you are interested in better inference of consistent clades, `--better-mccs` (default for 2 trees). Use the flag `--help-defaults` with dummy arguments for more details (*e.g.* `treeknit x y --help-defaults`).
+We suggest two sets of defaults for running TreeKnit. `--better-trees` will produce more accurately resolved trees (default for more than two trees). If you are interested in better inference of consistent clades, `--better-MCCs` (default for 2 trees). Use the flag `--help-defaults` with dummy arguments for more details (*e.g.* `treeknit x y --help-defaults`).
 
 # Arguments
 

--- a/src/cli.jl
+++ b/src/cli.jl
@@ -233,7 +233,7 @@ end
 
 function set_up_optargs(
 	K::Int,
-	γ::Real,
+	γ::Float64,
 	likelihood_sort::Bool,
 	nMCMC::Int,
 	seq_lengths::AbstractVector{Int},

--- a/src/cli.jl
+++ b/src/cli.jl
@@ -20,7 +20,7 @@ We suggest two sets of defaults for running TreeKnit. `--better-trees` will prod
 
 # Flags
 
-- `--help-defaults`: Print some information about the default settings `--better-trees` and `-better-mccs`. Can only be used with (possibily dummy) arguments, *e.g.* `treeknit x y --help-defaults`.
+- `--help-defaults`: Print some information about the default settings `--better-trees` and `-better-MCCs`. Can only be used with (possibily dummy) arguments, *e.g.* `treeknit x y --help-defaults`.
 - `--better-trees`: Use the `--better-trees` method (default for more than 2 trees)
 - `--better-MCCs`: Use the `--better-MCCs` method (default for 2 trees)
 - `--naive`: Naive inference (overrides `-g`).

--- a/src/objects.jl
+++ b/src/objects.jl
@@ -31,7 +31,7 @@ Storing parameters for `SplitGraph.runopt` function.
 - `nT::Int = 3000`: number of steps in the cooling schedule
 """
 @with_kw mutable struct OptArgs
-	γ::Real = 2
+	γ::Real = 2.
 	itmax::Int64 = 15
 	likelihood_sort::Bool = true
 	resolve::Bool = true

--- a/src/objects.jl
+++ b/src/objects.jl
@@ -8,7 +8,7 @@
 Storing parameters for `SplitGraph.runopt` function.
 
 ### General
-- `γ::Real = 2`
+- `γ::Float64 = 2`
 - `itmax::Int64 = 15`: maximal number of iterations of naive MCCs / SA cycles.
 - `likelihood_sort::Bool = true`: sort equivalent configurations using likelihood test
   based on branch length.
@@ -31,7 +31,7 @@ Storing parameters for `SplitGraph.runopt` function.
 - `nT::Int = 3000`: number of steps in the cooling schedule
 """
 @with_kw mutable struct OptArgs
-	γ::Real = 2.
+	γ::Float64 = 2.
 	itmax::Int64 = 15
 	likelihood_sort::Bool = true
 	resolve::Bool = true


### PR DESCRIPTION
Hi Pierre!
I was testing the new version of treetime and I got the following error. When calling:
```sh
treeknit examples/tree_h3n2_ha.nwk examples/tree_h3n2_na.nwk 
```
on the example data I got:
```
ERROR: LoadError: MethodError: no method matching var"#treeknit#162"(::String, ::Int64, ::String, ::Int64, ::Int64, ::Int64, ::Bool, ::Bool, ::Bool, ::Bool, ::Bool, ::Bool, ::Bool, ::Bool, ::Bool, ::Bool, ::Bool, ::Bool, ::typeof(TreeKnit.treeknit), ::String, ::String)
Closest candidates are:
  var"#treeknit#162"(::AbstractString, ::Float64, ::AbstractString, ::Int64, ::Int64, ::Int64, ::Bool, ::Bool, ::Bool, ::Bool, ::Bool, ::Bool, ::Bool, ::Bool, ::Bool, ::Bool, ::Bool, ::Bool, ::typeof(TreeKnit.treeknit), ::AbstractString, ::AbstractString, ::AbstractString...) at ~/Documents/code/TreeKnit.jl/src/cli.jl:36
Stacktrace:
 [1] treeknit(::String, ::String)
   @ TreeKnit ~/Documents/code/TreeKnit.jl/src/cli.jl:59
 [2] command_main(ARGS::Vector{String})
   @ TreeKnit ~/.julia/packages/Comonicon/AXDxW/src/codegen/julia.jl:343
 [3] command_main()
   @ TreeKnit ~/.julia/packages/Comonicon/AXDxW/src/codegen/julia.jl:90
 [4] top-level scope
   @ ~/.julia/bin/treeknit:15
in expression starting at /home/marco/.julia/bin/treeknit:15
```
This does not happen if I explicitly set `--gamma 2` when I call treeknit.

After some investigation I think this is due to the change introduced in #38, where [gamma became a float](https://github.com/PierreBarrat/TreeKnit.jl/blob/0f60e93cc207d83a7bca50267d70baad6bcda44d/src/cli.jl#L40), but [not in the default arguments](https://github.com/PierreBarrat/TreeKnit.jl/blob/0f60e93cc207d83a7bca50267d70baad6bcda44d/src/objects.jl#L34).

The minimal change that I can make to fix the error is just to change [the line](https://github.com/PierreBarrat/TreeKnit.jl/blob/0f60e93cc207d83a7bca50267d70baad6bcda44d/src/objects.jl#L34):
```julia
γ::Real = 2
```
to
```julia
γ::Real = 2.
```

With this change now 
```sh
treeknit examples/tree_h3n2_ha.nwk examples/tree_h3n2_na.nwk 
```
works.

I also changed the type of gamma to `Float64` in `OptArgs` and `set_up_optargs`, but feel free to revert this if there is a reason to keep it to `Real`.

Hope this is helpful!

Marco